### PR TITLE
fixup footnotes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,6 +25,10 @@ highlight_theme = "base16-ocean-dark"
 
 smart_punctuation = true
 
+# Make footnotes actually work
+# Thanks, totikom, for working on <https://github.com/getzola/zola/pull/2480>
+bottom_footnotes = true
+
 [extra]
 # Put all your custom variables here
 

--- a/themes/terminimal/sass/post.scss
+++ b/themes/terminimal/sass/post.scss
@@ -101,7 +101,7 @@
       color: var(--accent);
     }
   }  
-  
+ 
   ol {
     list-style: none;
     counter-reset: li;
@@ -122,7 +122,8 @@
      content: counter(li, katakana);
   }
   
-  ol li ol li ol>li::before {
+  ol li ol li ol>li::before,
+  .footnotes-list li::before {
      content: counter(li);
   }
 
@@ -157,5 +158,11 @@
 }
 
 ul li.tag-list a {
+  text-decoration: none;
+}
+
+.footnote-reference a {
+  color: var(--color);
+  opacity: .5;
   text-decoration: none;
 }


### PR DESCRIPTION
full disclosure: I've made this patch about 3 months ago and I remember NOTHING.

this is what I wrote at the time:

> they are still using [1] in the references (when is new zola release .-.) but at least they generally work!
