### PR TITLE
disable slugification for paths

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,6 +29,13 @@ smart_punctuation = true
 # Thanks, totikom, for working on <https://github.com/getzola/zola/pull/2480>
 bottom_footnotes = true
 
+[slugify]
+# My paths are already basically slugs;
+# "on" makes everything lowercase, which looks off for hex post prefix
+# (i.e. 0A-blah turns into 0a-blah which doesn't look good, because
+# 0-9 numbers are basically always uppercase)
+paths = "off"
+
 [extra]
 # Put all your custom variables here
 

--- a/content/0A-null-data-0x06.md
+++ b/content/0A-null-data-0x06.md
@@ -3,6 +3,10 @@ title = "(null), data= [ 0x06 ]"
 date = 2025-04-13
 description = "debugging lsusb"
 
+# redirect from lowercase hex url,
+# which was used before I turned off slugification of paths.
+aliases = ["0a-null-data-0x06"]
+
 [taxonomies] 
 tags = ["usb", "programming", "lowercase"]
 +++


### PR DESCRIPTION
1. my paths are already basically slugs
2. this makes urls with letter hex (i.e. 0A) look nicer -- slugification turned them into lowercase letters (0a) which is not nice, given that 0-9 numbers are always kinda uppercase

![image](https://github.com/user-attachments/assets/54296742-c3bd-4e2c-84c4-2331afe23138)
